### PR TITLE
refactor: update default `ingress_cidr_blocks`

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -21,7 +21,6 @@ description: |-
           enabled: true
           name: "elasticache-redis"
           family: redis6.x
-          ingress_cidr_blocks: []
           egress_cidr_blocks: ["0.0.0.0/0"]
           port: 6379
           at_rest_encryption_enabled: true

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -28,6 +28,7 @@ variable "port" {
 variable "ingress_cidr_blocks" {
   type        = list(string)
   description = "CIDR blocks for permitted ingress"
+  default     = []
 }
 
 variable "allow_all_egress" {


### PR DESCRIPTION
## what

This pull request introduces a default value for the `ingress_cidr_blocks` variable in the `src/variables.tf` file to ensure it defaults to an empty list when not explicitly provided.

Key change:

* [`src/variables.tf`](diffhunk://#diff-e64d396480ef61e94c68b45e4940f63bdb28cce844c90404d648122910254904R31): Added a default value of `[]` to the `ingress_cidr_blocks` variable. This change ensures that the variable has a default value, making it optional for users to define it explicitly.

## why

- Not providing a default ingress value fails

```console
│ Error: No value for required variable
│
│   on variables.tf line 28:
│   28: variable "ingress_cidr_blocks" {
│
│ The root module input variable "ingress_cidr_blocks" is not set, and has no
│ default value. Use a -var or -var-file command line argument to provide a
│ value for this variable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration in the documentation to remove an unused variable with an empty value.

* **New Features**
  * Made the `ingress_cidr_blocks` setting optional by providing a default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->