### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }
@@ -22,7 +22,7 @@ module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "dns-delegated"
+  component   = var.dns_delegated_component_name
   environment = "gbl"
 
   context = module.this.context
@@ -34,7 +34,7 @@ module "vpc_ingress" {
 
   for_each = toset(var.allow_ingress_from_vpc_stages)
 
-  component = "vpc"
+  component = var.vpc_ingress_component_name
   stage     = each.key
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -111,3 +111,21 @@ variable "snapshot_retention_limit" {
   description = "The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them."
   default     = 0
 }
+
+variable "vpc_component_name" {
+  type        = string
+  description = "The name of a VPC component"
+  default     = "vpc"
+}
+
+variable "vpc_ingress_component_name" {
+  type        = string
+  description = "The name of a Ingress VPC component"
+  default     = "vpc"
+}
+
+variable "dns_delegated_component_name" {
+  type        = string
+  description = "The name of the Delegated DNS component"
+  default     = "dns_delegated"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -127,5 +127,5 @@ variable "vpc_ingress_component_name" {
 variable "dns_delegated_component_name" {
   type        = string
   description = "The name of the Delegated DNS component"
-  default     = "dns_delegated"
+  default     = "dns-delegated"
 }


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `vpc_component_name`, `vpc_ingress_component_name` and `dns_delegated_component_name`.
* Variables default to preserving the behaviour of the current version.
* Remote state uses these variables to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration options to customize component names for VPC, Ingress VPC, and Delegated DNS modules.
* **Chores**
  * Updated module settings to use configurable variables for component names instead of fixed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->