### PR TITLE
feat: expose security group ID for ElastiCache Redis cluster

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -2,3 +2,8 @@ output "redis_clusters" {
   description = "Redis cluster objects"
   value       = local.enabled ? local.clusters : {}
 }
+
+output "security_group_id" {
+  description = "The security group ID of the ElastiCache Redis cluster"
+  value       = local.enabled ? module.redis_clusters[keys(var.redis_clusters)[0]].security_group_id : null
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -5,5 +5,5 @@ output "redis_clusters" {
 
 output "security_group_id" {
   description = "The security group ID of the ElastiCache Redis cluster"
-  value       = local.enabled ? module.redis_clusters[keys(var.redis_clusters)[0]].security_group_id : null
+  value       = local.enabled ? try(module.redis_clusters[keys(var.redis_clusters)[0]].security_group_id, null) : null
 }


### PR DESCRIPTION
## what
- Add security_group_id output to expose the security group ID from the underlying ElastiCache Redis module

## why
- This enables proper configuration of inbound and outbound traffic rules for ECS services

## references
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new output that exposes the security group ID for the first Redis cluster when the module is enabled.
  - The output returns null when the module is disabled or the attribute is unavailable, avoiding errors.
  - Additive change that does not modify existing outputs, preserving backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->