### PR TITLE
feat: `transit_encryption_mode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ github/
 *.ovpn
 
 *.zip
+account-map/

--- a/src/main.tf
+++ b/src/main.tf
@@ -47,6 +47,7 @@ locals {
     port                             = var.port
     at_rest_encryption_enabled       = var.at_rest_encryption_enabled
     transit_encryption_enabled       = var.transit_encryption_enabled
+    transit_encryption_mode          = var.transit_encryption_mode
     apply_immediately                = var.apply_immediately
     automatic_failover_enabled       = var.automatic_failover_enabled
     auto_minor_version_upgrade       = var.auto_minor_version_upgrade

--- a/src/modules/redis_cluster/main.tf
+++ b/src/modules/redis_cluster/main.tf
@@ -5,7 +5,7 @@ locals {
 
   ssm_path_auth_token = local.auth_token_enabled ? format("/%s/%s/%s", "elasticache-redis", var.cluster_name, "auth_token") : null
 
-  auth_token = local.auth_token_enabled ? join("", random_password.auth_token.*.result) : null
+  auth_token = local.auth_token_enabled ? random_password.auth_token[0].result : null
 }
 
 module "redis" {

--- a/src/modules/redis_cluster/main.tf
+++ b/src/modules/redis_cluster/main.tf
@@ -5,7 +5,7 @@ locals {
 
   ssm_path_auth_token = local.auth_token_enabled ? format("/%s/%s/%s", "elasticache-redis", var.cluster_name, "auth_token") : null
 
-  auth_token = local.auth_token_enabled ? random_password.auth_token[0].result : null
+  auth_token = local.auth_token_enabled ? one(random_password.auth_token[*].result) : null
 }
 
 module "redis" {

--- a/src/modules/redis_cluster/main.tf
+++ b/src/modules/redis_cluster/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "redis" {
   source  = "cloudposse/elasticache-redis/aws"
-  version = "1.9.2"
+  version = "1.10.0"
 
   name = var.cluster_name
 
@@ -39,6 +39,7 @@ module "redis" {
   port                                 = var.cluster_attributes.port
   subnets                              = var.cluster_attributes.subnets
   transit_encryption_enabled           = var.cluster_attributes.transit_encryption_enabled
+  transit_encryption_mode              = var.cluster_attributes.transit_encryption_mode
   snapshot_retention_limit             = var.cluster_attributes.snapshot_retention_limit
   vpc_id                               = var.cluster_attributes.vpc_id
   zone_id                              = var.cluster_attributes.zone_id

--- a/src/modules/redis_cluster/outputs.tf
+++ b/src/modules/redis_cluster/outputs.tf
@@ -29,6 +29,6 @@ output "cluster_ssm_path_auth_token" {
 }
 
 output "transit_encryption_mode" {
-  value       = local.enabled ? var.cluster_attributes.transit_encryption_mode : null
+  value       = local.enabled ? module.redis.transit_encryption_mode : null
   description = "TLS in-transit encryption mode for Redis cluster"
 }

--- a/src/modules/redis_cluster/outputs.tf
+++ b/src/modules/redis_cluster/outputs.tf
@@ -27,3 +27,8 @@ output "cluster_ssm_path_auth_token" {
   value       = local.ssm_path_auth_token
   description = "SSM path of Redis auth_token"
 }
+
+output "transit_encryption_mode" {
+  value       = module.redis.transit_encryption_mode
+  description = "TLS in-transit encryption mode for Redis cluster"
+}

--- a/src/modules/redis_cluster/outputs.tf
+++ b/src/modules/redis_cluster/outputs.tf
@@ -29,6 +29,6 @@ output "cluster_ssm_path_auth_token" {
 }
 
 output "transit_encryption_mode" {
-  value       = local.enabled ? module.redis.transit_encryption_mode : null
+  value       = module.redis.transit_encryption_mode
   description = "TLS in-transit encryption mode for Redis cluster"
 }

--- a/src/modules/redis_cluster/outputs.tf
+++ b/src/modules/redis_cluster/outputs.tf
@@ -29,6 +29,6 @@ output "cluster_ssm_path_auth_token" {
 }
 
 output "transit_encryption_mode" {
-  value       = module.redis.transit_encryption_mode
+  value       = local.enabled ? var.cluster_attributes.transit_encryption_mode : null
   description = "TLS in-transit encryption mode for Redis cluster"
 }

--- a/src/modules/redis_cluster/variables.tf
+++ b/src/modules/redis_cluster/variables.tf
@@ -64,6 +64,7 @@ variable "cluster_attributes" {
     multi_az_enabled                = bool
     at_rest_encryption_enabled      = bool
     transit_encryption_enabled      = bool
+    transit_encryption_mode         = string
     apply_immediately               = bool
     automatic_failover_enabled      = bool
     auto_minor_version_upgrade      = bool

--- a/src/modules/redis_cluster/variables.tf
+++ b/src/modules/redis_cluster/variables.tf
@@ -88,6 +88,7 @@ variable "parameter_group_name" {
 }
 
 variable "kms_alias_name_ssm" {
+  type        = string
   default     = "alias/aws/ssm"
   description = "KMS alias name for SSM"
 }

--- a/src/modules/redis_cluster/versions.tf
+++ b/src/modules/redis_cluster/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0, < 6.0.0"
-    }
     random = {
       source  = "hashicorp/random"
       version = ">= 3.0"

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -7,3 +7,8 @@ output "security_group_id" {
   description = "The security group ID of the ElastiCache Redis cluster"
   value       = local.enabled ? try(module.redis_clusters[keys(var.redis_clusters)[0]].security_group_id, null) : null
 }
+
+output "transit_encryption_mode" {
+  description = "TLS in-transit encryption mode for Redis cluster"
+  value       = local.enabled ? try(module.redis_clusters[keys(var.redis_clusters)[0]].transit_encryption_mode, null) : null
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -50,6 +50,12 @@ variable "transit_encryption_enabled" {
   description = "Enable TLS"
 }
 
+variable "transit_encryption_mode" {
+  type        = string
+  default     = null
+  description = "Transit encryption mode. Valid values are 'preferred' and 'required'"
+}
+
 variable "auth_token_enabled" {
   type        = bool
   description = "Enable auth token"


### PR DESCRIPTION
## what
- Add output for transit encryption mode in Redis cluster
- Fix TFLint warnings

## why
- When "Encryption in transit" is enabled for Redis, the transit_encryption_mode must also be set.

## references
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Surfaces TLS in‑transit encryption mode for Redis clusters via a new top‑level variable and outputs.

- **Refactor**
  - Simplified internal token handling for Redis clusters.
  - Added explicit typing for a module variable to improve validation.
  - Removed an unnecessary provider requirement from the Redis module.
  - Bumped Redis module version to a newer release.

- **Chores**
  - Updated repository ignore rules to exclude account-map directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->