### PR TITLE
fix: null errors with default config

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -74,7 +74,7 @@ module "redis_clusters" {
   engine                 = lookup(each.value, "engine", "redis")
   engine_version         = each.value.engine_version
   create_parameter_group = lookup(each.value, "create_parameter_group", true)
-  parameters             = lookup(each.value, "parameters", null)
+  parameters             = lookup(each.value, "parameters", [])
   parameter_group_name   = lookup(each.value, "parameter_group_name", null)
   cluster_attributes     = local.cluster_attributes
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -74,7 +74,7 @@ module "redis_clusters" {
   engine                 = lookup(each.value, "engine", "redis")
   engine_version         = each.value.engine_version
   create_parameter_group = lookup(each.value, "create_parameter_group", true)
-  parameters             = try(each.value.parameters, null) != null ? each.value.parameters : []
+  parameters             = lookup(each.value, "parameters", [])
   parameter_group_name   = lookup(each.value, "parameter_group_name", null)
   cluster_attributes     = local.cluster_attributes
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -74,7 +74,7 @@ module "redis_clusters" {
   engine                 = lookup(each.value, "engine", "redis")
   engine_version         = each.value.engine_version
   create_parameter_group = lookup(each.value, "create_parameter_group", true)
-  parameters             = lookup(each.value, "parameters", [])
+  parameters             = try(each.value.parameters, null) != null ? each.value.parameters : []
   parameter_group_name   = lookup(each.value, "parameter_group_name", null)
   cluster_attributes     = local.cluster_attributes
 

--- a/src/modules/redis_cluster/variables.tf
+++ b/src/modules/redis_cluster/variables.tf
@@ -80,6 +80,7 @@ variable "parameters" {
     value = string
   }))
   description = "Parameters to configure cluster parameter group"
+  default     = []
 }
 
 variable "parameter_group_name" {


### PR DESCRIPTION
## what
* fix: null errors with default config

## why
* Default values are undeployable 

## references
* `closes #59 `


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Redis cluster parameter handling updated: missing parameters now default to an empty list instead of null.
  * Invocation behavior aligned with module defaults so clusters consistently receive an empty parameters list when none are provided, avoiding null-related inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->