### PR TITLE
fix: bump aws minimum provider

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0, < 7.0.0"
+      version = ">= 5.73.0, < 7.0.0"
     }
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.73.0, < 6.0.0"
+      version = ">= 6.0.0, < 7.0.0"
     }
   }
 }


### PR DESCRIPTION
## what
- fix: bump aws minimum provider

## why
- We're migrating from the cloudposse/terraform-aws-components which did not have a maximum constraint so we ended up using the 6.x provider. When we vendored this component in, we were unable to plan our components due to errors since the resources were provisioned with the latest 6.x provider instead of the latest 5.x provider

## references
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS provider version compatibility to support releases up to version 7.0.0, enabling access to the latest AWS service features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->