### PR TITLE
chore: update remote-state to 2.0.0 and switch to standalone account-map

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.vpc_component_name
 
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   for_each = local.eks_security_group_enabled ? var.eks_component_names : toset([])
 
@@ -20,7 +20,7 @@ module "eks" {
 
 module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.dns_delegated_component_name
   environment = "gbl"
@@ -30,7 +30,7 @@ module "dns_delegated" {
 
 module "vpc_ingress" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   for_each = toset(var.allow_ingress_from_vpc_stages)
 

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = ">= 1.7.1, != 1.4.0, < 3.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:
@@ -19,7 +19,7 @@ spec:
 
     - component: "vpc"
       source: github.com/cloudposse-terraform-components/aws-vpc.git//src?ref={{.Version}}
-      version: v1.536.0
+      version: v2.1.2
       targets:
         - "components/terraform/vpc"
       included_paths:
@@ -31,7 +31,7 @@ spec:
 
     - component: "dns-delegated"
       source: github.com/cloudposse-terraform-components/aws-dns-delegated.git//src?ref={{.Version}}
-      version: v1.535.1
+      version: v1.537.1
       targets:
         - "components/terraform/dns-delegated"
       included_paths:


### PR DESCRIPTION
## Summary
- Update `cloudposse/stack-config/yaml//modules/remote-state` from `1.8.0` to `2.0.0`
- Switch vendor.yaml `account-map` source from `cloudposse/terraform-aws-components` monorepo to standalone `cloudposse-terraform-components/aws-account-map` at `v1.537.2`

The monorepo account-map uses remote-state v1.5.0 which constrains `cloudposse/utils` to `< 2.0.0`, conflicting with remote-state v2.0.0 which requires `>= 2.0.0`. This was causing the `terraform init` lint failure.

## Test plan
- [ ] Verify CI lint passes
- [ ] Verify terratest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)